### PR TITLE
fix: attributes-now-level-up

### DIFF
--- a/Assets/Scripts/Player/SkillSystem/SkillUsageTracker.cs
+++ b/Assets/Scripts/Player/SkillSystem/SkillUsageTracker.cs
@@ -1,6 +1,6 @@
 public static class SkillUsageTracker
 {
-    private const float AttributeXPPercent = 0.5f;
+    private const float AttributeXPPercent = 10f;
 
     public static void RegisterSkillUse(SkillType skill, float xpAmount)
     {


### PR DESCRIPTION
fixed attributes not leveling up. It was already working, but the amount was set incredibly low. Up'd it so now every 5 skill points you gain an attribute point.